### PR TITLE
Handle new mirth-resources-api repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository is used in [this guide on writing Mirth plugins](https://github.
 1. [Install Java](https://www.javatpoint.com/javafx-how-to-install-java)
 1. [Install Maven](https://www.javatpoint.com/how-to-install-maven)
 1. Run `git clone https://github.com/kpalang/mirth-sample-plugin`
+1. Copy m2settings.xml to use as your local maven settings.xml, located in .m2 under your home directory, or include the <servers> material from m2settings.xml in your existing ~/.m2/settings.xml
 1. Navigate to `mirth-sample-plugin/`
 1. Run `mvn install` to install dependencies to local cache
 1. Run `mvn clean package` to verify the build works

--- a/m2settings.xml
+++ b/m2settings.xml
@@ -1,0 +1,36 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/kpalang/mirth-releases-api</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>kpalang</username>
+      <password>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</password>
+    </server>
+  </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
 
     <repositories>
         <repository>
-            <id>nexus</id>
-            <url>https://maven.kaurpalang.com/repository/maven-public/</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/kpalang/mirth-resources-api/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
By including a settings file for maven which includes the new repo and server username/password, referencing the new repo in pom.xml and mentioning the requirement to get access to its server in README